### PR TITLE
Add `encode_to_writer` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ A quoted-printable decoder and encoder.
 
 API
 ---
-quoted-printable exposes two functions at the moment:
+quoted-printable exposes four functions at the moment:
 
 ```rust
     decode<R: AsRef<[u8]>>(input: R, mode: ParseMode) -> Result<Vec<u8>, QuotedPrintableError>
     encode<R: AsRef<[u8]>>(input: R) -> Vec<u8>
     encode_to_str<R: AsRef<[u8]>>(input: R) -> String
+    encode_to_writer<R: AsRef<[u8]>, W: Write>(writer: &mut W, input: R) -> std::io::Result<()>
 ```
 
 using `R: AsRef<[u8]>` means that you can pass in a variety of types, including:


### PR DESCRIPTION
This PR adds an `encode_to_writer` function to the top-level api. It also changes the underlying _encode implementation to use write into a buffer that was passed into it instead of allocating it's own buffer. 

The motivation behind this change is to expose an `encode` function that users can use when they need to conserve allocations or with less memory. 

Note: there was a difference in behavior between the previous implementation and this implementation of quoted-printable. Both are valid according to RFC1521 however, I had to make a change to the algorithm to insert `=\r\n` eagerly at character 75 because we could no longer use `insert_str` to the write into the previous byte position.

Whereas before, the algorithm would append a `=\r\n` at the previous byte, if was about to append the 76th character. I avoid that case by ensuring the line always wraps before line 76th character. 

The result of this difference: if the last line to encode has 76 characters, the new algorithm will  wrap the last byte into a new line whereas the old algorithm would fit that last byte into the same last line. 

### For an example: 
For simplicity, let say the max line length is 5 instead of 76:

Before we'd write 
```
ABCDABCDE
```
To
```
ABCD=\r\n
ABCDE
```
Now it'll convert that to: 
```
ABCD=\r\n
ABCD=\r\n
E
```
Because the algorithm doesn't wait to find out if there's going to be a 76th character before wrapping. It wraps more eagerly.