### PR TITLE
add `no_std` support

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  stable:
+    name: Run no_std tests on stable rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest stable Rust
+        run: rustup toolchain install stable --profile minimal
+      - name: Check out source
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: cargo test --all --no-default-features
+  beta:
+    name: Run no_std tests on beta rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest beta Rust
+        run: rustup toolchain install beta --profile minimal
+      - name: Check out source
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: cargo test --all --no-default-features
+  nightly:
+    name: Run no_std tests on nightly rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest nightly Rust
+        run: rustup toolchain install nightly --profile minimal
+      - name: Check out source
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: cargo test --all --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ exclude = [".gitignore", ".github/**"]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ In general you should probably use "robust" decoding, as it will gracefully hand
 
 The encode and encode_to_str functions obviously do the reverse, and convert a set of raw bytes into quoted-printable.
 
+no_std
+---
+
+This crate supports no_std. By default the crate targets std via the `std` feature. You can deactivate the `default-features`  to support `no_std` like this:
+
+```toml
+quoted-printable = { version = "*", default-features = false }
+```
+
 Documentation
 ---
 See document on [https://docs.rs](https://docs.rs/quoted_printable/).


### PR DESCRIPTION
add `no_std` feature support.

## How to use

in `Cargo.toml`
```toml
quoted_printable = { version = "*", default-features = false, features = [
    "alloc",
] }
```