### PR TITLE
Speed up encode()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,14 +462,15 @@ fn _encode(input: &[u8], options: Options) -> lib::String {
         if limit - on_line >= 3 && !needs_encoding(byte) {
             // peek ahead up to max line length and copy the run directly into the output
             let mut run_len: usize = 1;
-            let max_run_len = limit - on_line - 3;
+            let max_run_len: usize = limit - on_line - 2;
+            debug_assert!(max_run_len >= run_len);
 
             // add the char to result directly - safe because we know we're not at the line length limit
             result.push(byte as char);
 
             // look ahead for a run of characters we can put directly into the result
             while let Some(&&next_byte) = it.peek() {
-                if run_len >= max_run_len {
+                if run_len == max_run_len {
                     break;
                 }
                 if needs_encoding(next_byte) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,7 @@ fn _encode(input: &[u8], options: Options) -> lib::String {
 	// is very common (QP is normally used on ASCII text where
 	// most characters don't need encoding) and much faster than
 	// calling encode_byte on each character.  To keep this from
-	// completely reimplmenting append(), only do this if we have
+	// completely reimplementing append(), only do this if we have
 	// at least 3 characters left on the line and don't try to
 	// deal with the line-ending stuff.
 	if limit - on_line >= 3 && !needs_encoding(byte) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,48 +452,48 @@ fn _encode(input: &[u8], options: Options) -> lib::String {
             was_cr = false;
         }
 
-	// look for runs of characters that don't need encoding - this
-	// is very common (QP is normally used on ASCII text where
-	// most characters don't need encoding) and much faster than
-	// calling encode_byte on each character.  To keep this from
-	// completely reimplementing append(), only do this if we have
-	// at least 3 characters left on the line and don't try to
-	// deal with the line-ending stuff.
-	if limit - on_line >= 3 && !needs_encoding(byte) {
-	    // peek ahead up to max line length and copy the run directly into the output
-	    let mut run_len: usize = 1;
-	    let max_run_len = limit - on_line - 3;
+        // look for runs of characters that don't need encoding - this
+        // is very common (QP is normally used on ASCII text where
+        // most characters don't need encoding) and much faster than
+        // calling encode_byte on each character.  To keep this from
+        // completely reimplementing append(), only do this if we have
+        // at least 3 characters left on the line and don't try to
+        // deal with the line-ending stuff.
+        if limit - on_line >= 3 && !needs_encoding(byte) {
+            // peek ahead up to max line length and copy the run directly into the output
+            let mut run_len: usize = 1;
+            let max_run_len = limit - on_line - 3;
 
-	    // add the char to result directly - safe because we know we're not at the line length limit
-	    result.push(byte as char);
+            // add the char to result directly - safe because we know we're not at the line length limit
+            result.push(byte as char);
 
-	    // look ahead for a run of characters we can put directly into the result
-	    while let Some(&&next_byte) = it.peek() {
-		if run_len >= max_run_len {
-		    break;
-		}
-		if needs_encoding(next_byte) {
-		    break;
-		}
+            // look ahead for a run of characters we can put directly into the result
+            while let Some(&&next_byte) = it.peek() {
+                if run_len >= max_run_len {
+                    break;
+                }
+                if needs_encoding(next_byte) {
+                    break;
+                }
 
-		run_len += 1;
+                run_len += 1;
 
-		// add the next char to result directly - this is safe
-		// because we're not close to the line length limit
-		result.push(next_byte as char);
+                // add the next char to result directly - this is safe
+                // because we're not close to the line length limit
+                result.push(next_byte as char);
 
-		// consume the byte so we don't see it again
-		it.next();
-	    }
+                // consume the byte so we don't see it again
+                it.next();
+            }
 
-	    // update counters for where we are in the line and what was last appended
-	    on_line += run_len;
-	    backup_pos = result.len();
-	    
-	    continue;
-	}
+            // update counters for where we are in the line and what was last appended
+            on_line += run_len;
+            backup_pos = result.len();
 
-	encode_byte(&mut result, byte, &mut on_line, limit, &mut backup_pos);
+            continue;
+        }
+
+        encode_byte(&mut result, byte, &mut on_line, limit, &mut backup_pos);
     }
 
     // we haven't yet encoded the last CR ('\r') so do it now
@@ -515,9 +515,9 @@ fn _encode(input: &[u8], options: Options) -> lib::String {
 #[inline(always)]
 fn needs_encoding(c: u8) -> bool {
     return match c {
-	b'=' => true,
-	b'\t' | b' '..=b'~' => false,
-	_ => true,
+        b'=' => true,
+        b'\t' | b' '..=b'~' => false,
+        _ => true,
     };
 }
 
@@ -877,11 +877,11 @@ mod tests {
 
     #[test]
     fn test_three() {
-	// this test enters the fast path for encoding runs of
-	// characters that don't need encoding with three characters
-	// left on the line and the next character needing encoding -
-	// checks for potential off-by-one mistake in that loop
-	assert_eq!(
+        // this test enters the fast path for encoding runs of
+        // characters that don't need encoding with three characters
+        // left on the line and the next character needing encoding -
+        // checks for potential off-by-one mistake in that loop
+        assert_eq!(
 	    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=3DX=\r\n=3D=3DY",
             encode_to_str(
 		"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=X==Y",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -874,4 +874,18 @@ mod tests {
             encode_binary_to_str("\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n")
         );
     }
+
+    #[test]
+    fn test_three() {
+	// this test enters the fast path for encoding runs of
+	// characters that don't need encoding with three characters
+	// left on the line and the next character needing encoding -
+	// checks for potential off-by-one mistake in that loop
+	assert_eq!(
+	    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=3DX=\r\n=3D=3DY",
+            encode_to_str(
+		"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=X==Y",
+            )
+        );
+    }
 }


### PR DESCRIPTION
This PR improves the speed of encode() by more than 2x.  On a corpus of test data consisting of a mix of text and HTML totaling `476kb` I get these results before my change:

```Encoding: 1000 runs took 2.4 sec - 414.72 iterations per second```

And after my change:

```Encoding: 1000 runs took 0.9 sec - 1054.39 iterations per second```

The test data is in the `data` directory here: 

https://github.com/samtregar/zoomascii

The way this change works is by scanning ahead for runs of characters that do not need to be encoded and pushing them directly into the output.  This is very common in the kinds of text that QP is used on, so it provides a big speedup.  Encoding speed for QP encoding is important for applications like mass email sending, for example.

If it seems useful I can also commit my benchmarking binary, or I can include it on this PR if you'd like to play with it but don't think it's worth including in the repo.