### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,11 +515,11 @@ fn _encode(input: &[u8], options: Options) -> lib::String {
 
 #[inline(always)]
 fn needs_encoding(c: u8) -> bool {
-    return match c {
+    match c {
         b'=' => true,
         b'\t' | b' '..=b'~' => false,
         _ => true,
-    };
+    }
 }
 
 /// Encodes some bytes into quoted-printable format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,12 +263,11 @@ fn _decode(input: &[u8], options: Options) -> Result<lib::Vec<u8>, QuotedPrintab
                 let upper_char = upper as char;
                 let lower_char = lower as char;
                 if upper_char.is_ascii_hexdigit() && lower_char.is_ascii_hexdigit() {
-                    if options.parse_mode == ParseMode::Strict {
-                        if upper_char.to_uppercase().next() != Some(upper_char)
-                            || lower_char.to_uppercase().next() != Some(lower_char)
-                        {
-                            return Err(QuotedPrintableError::LowercaseHexOctet);
-                        }
+                    if options.parse_mode == ParseMode::Strict
+                        && (upper_char.to_uppercase().next() != Some(upper_char)
+                            || lower_char.to_uppercase().next() != Some(lower_char))
+                    {
+                        return Err(QuotedPrintableError::LowercaseHexOctet);
                     }
                     let combined =
                         upper_char.to_digit(16).unwrap() << 4 | lower_char.to_digit(16).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ fn encode_trailing_space_tab(
             append(result, &['=', '0', '9'], bytes_on_line, limit, backup_pos);
         }
         _ => (),
-    };
+    }
 }
 
 /// Encodes some bytes into quoted-printable format, treating the input as text.
@@ -432,7 +432,7 @@ fn _encode(input: &[u8], options: Options) -> lib::String {
                             &mut backup_pos,
                         );
                     }
-                };
+                }
                 was_cr = false;
                 continue;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,14 +61,6 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn default() -> Self {
-        Options {
-            line_length_limit: 76,
-            input_mode: InputMode::Text,
-            parse_mode: ParseMode::Robust,
-        }
-    }
-
     pub fn line_length_limit(mut self, limit: usize) -> Self {
         self.line_length_limit = limit;
         self
@@ -82,6 +74,16 @@ impl Options {
     pub fn parse_mode(mut self, mode: ParseMode) -> Self {
         self.parse_mode = mode;
         self
+    }
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            line_length_limit: 76,
+            input_mode: InputMode::Text,
+            parse_mode: ParseMode::Robust,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ fn append(
         }
     }
     result.extend(to_append);
-    *bytes_on_line = *bytes_on_line + to_append.len();
+    *bytes_on_line += to_append.len();
     *backup_pos = result.len() - to_append.len();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ fn _decode(input: &[u8], options: Options) -> Result<lib::Vec<u8>, QuotedPrintab
                 };
                 let upper_char = upper as char;
                 let lower_char = lower as char;
-                if upper_char.is_digit(16) && lower_char.is_digit(16) {
+                if upper_char.is_ascii_hexdigit() && lower_char.is_ascii_hexdigit() {
                     if options.parse_mode == ParseMode::Strict {
                         if upper_char.to_uppercase().next() != Some(upper_char)
                             || lower_char.to_uppercase().next() != Some(lower_char)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ pub fn decode_with_options<R: AsRef<[u8]>>(
 
 fn _decode(input: &[u8], options: Options) -> Result<lib::Vec<u8>, QuotedPrintableError> {
     let filtered = input
-        .into_iter()
+        .iter()
         .filter_map(|&c| match c {
             b'\t' | b'\r' | b'\n' | b' '..=b'~' => Some(c as char),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,9 +185,9 @@ pub fn decode<R: AsRef<[u8]>>(
 ///
 /// # Errors
 ///
-/// If this function is called with the ParseMode::Strict option, then it may return
-/// a QuotedPrintableError if it detects that the input does not strictly conform
-/// to the quoted-printable spec. If this function is called with ParseMode::Robust,
+/// If this function is called with the `ParseMode::Strict` option, then it may return
+/// a `QuotedPrintableError` if it detects that the input does not strictly conform
+/// to the quoted-printable spec. If this function is called with `ParseMode::Robust`,
 /// then it will attempt to gracefully handle any errors that arise. This might
 /// result in input bytes being stripped out and ignored in some cases. Refer
 /// to IETF RFC 2045, section 6.7 for details on what constitutes valid and


### PR DESCRIPTION
The `clippy::should_implement_trait` may be considerable as a breaking change.